### PR TITLE
fix: resolve Python 3.8 compatibility issues and add pip upgrade instructions

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -144,6 +144,7 @@ cd SoundDitect
 ```bash
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
+pip install --upgrade pip  # Important: Upgrade pip first
 pip install -r requirements.txt
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ cd SoundDitect
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
 
+# pipを最新バージョンにアップグレード（重要）
+pip install --upgrade pip
+
 # 依存関係をインストール
 pip install -r requirements.txt
 ```
@@ -215,6 +218,9 @@ cd SoundDitect
 # Create and activate virtual environment
 python -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
+
+# Upgrade pip to latest version (important)
+pip install --upgrade pip
 
 # Install dependencies
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
+# IMPORTANT: Run 'pip install --upgrade pip' before installing these dependencies
+# This ensures compatibility with all packages, especially PyTorch and audio libraries
+
 # Core Dependencies
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
@@ -8,7 +11,7 @@ python-multipart==0.0.6
 torch==2.1.0
 torchaudio==2.1.0
 numpy==1.24.3
-scipy==1.11.3
+scipy==1.10.1
 librosa==0.10.1
 scikit-learn==1.3.2
 


### PR DESCRIPTION
Successfully resolved Python 3.8 compatibility issues for SoundDitect project.

## 🔧 Issues Fixed
- **scipy version compatibility**: Updated from 1.11.3 to 1.10.1 (max available for Python 3.8)
- **pip upgrade requirement**: Added clear instructions to upgrade pip before installation
- **Documentation**: Updated both Japanese and English README files

## ✨ Changes Made
- Fixed scipy dependency version in requirements.txt
- Added pip upgrade instructions to requirements.txt header
- Updated setup steps in README.md (Japanese)
- Updated setup steps in README.en.md (English)

## 🧪 Testing
The fix addresses the specific error reported:
```
ERROR: Could not find a version that satisfies the requirement scipy==1.11.3
```

All dependencies should now install correctly on Python 3.8 systems.

Generated with [Claude Code](https://claude.ai/code)