### PR TITLE
fix: resolve PyTorch CNN padding/stride compatibility issue

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,11 +36,11 @@ model:
     - filters: 128
       kernel_size: 3
       stride: 2
-      padding: "same"
+      padding: 1
     - filters: 256
       kernel_size: 3
       stride: 2
-      padding: "same"
+      padding: 1
   
   attention:
     hidden_dim: 256


### PR DESCRIPTION
Fixed "padding='same' is not supported for strided convolutions" training error by:

- Changed CNN layers 2 & 3 padding from "same" to 1 for stride=2 compatibility
- Maintained "same" padding for layer 1 with stride=1
- Preserves model functionality while ensuring PyTorch compatibility

Resolves issue #3

Generated with [Claude Code](https://claude.ai/code)