### PR TITLE
fix: add missing Any import to memory_manager.py

### DIFF
--- a/backend/memory_manager.py
+++ b/backend/memory_manager.py
@@ -10,7 +10,7 @@ import os
 import psutil
 import torch
 import logging
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 from pathlib import Path
 import time
 


### PR DESCRIPTION
Resolves NameError: name 'Any' is not defined at line 607
- Added Any to typing imports for Dict[str, Any] type annotation
- This fixes the import error when initializing model training

Generated with [Claude Code](https://claude.ai/code)